### PR TITLE
[feat/#60] 주문서 생성 api

### DIFF
--- a/be/src/main/java/com/podmate/domain/orderForm/api/OrderFormRestController.java
+++ b/be/src/main/java/com/podmate/domain/orderForm/api/OrderFormRestController.java
@@ -1,0 +1,33 @@
+package com.podmate.domain.orderForm.api;
+
+import com.podmate.domain.orderForm.application.OrderFormService;
+import com.podmate.domain.orderForm.dto.OrderFormRequestDto;
+import com.podmate.global.common.code.status.SuccessStatus;
+import com.podmate.global.common.response.BaseResponse;
+import com.podmate.global.util.oauth2.dto.CustomOAuth2User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/orderforms")
+@RequiredArgsConstructor
+public class OrderFormRestController {
+    private final OrderFormService orderFormService;
+
+    @PostMapping
+    public BaseResponse<Long> createOrderForm(
+            @AuthenticationPrincipal CustomOAuth2User user,
+            @RequestParam(name = "podId", required = true) Long podId,
+            @RequestBody OrderFormRequestDto.ItemIds request
+            ){
+        Long orderFormId = orderFormService.createOrderForm(user.getUserId(), podId, request.getItems());
+
+        return BaseResponse.onSuccess(SuccessStatus._OK, orderFormId);
+    }
+
+}

--- a/be/src/main/java/com/podmate/domain/orderForm/application/OrderFormService.java
+++ b/be/src/main/java/com/podmate/domain/orderForm/application/OrderFormService.java
@@ -1,0 +1,8 @@
+package com.podmate.domain.orderForm.application;
+
+import java.util.List;
+
+public interface OrderFormService {
+    Long createOrderForm(Long userId, Long podId, List<Long> itemIds);
+
+}

--- a/be/src/main/java/com/podmate/domain/orderForm/application/OrderFormServiceImpl.java
+++ b/be/src/main/java/com/podmate/domain/orderForm/application/OrderFormServiceImpl.java
@@ -1,0 +1,116 @@
+package com.podmate.domain.orderForm.application;
+
+import com.podmate.domain.cart.domain.entity.CartItem;
+import com.podmate.domain.cart.domain.repository.CartItemRepository;
+import com.podmate.domain.orderForm.domain.entity.OrderForm;
+import com.podmate.domain.orderForm.domain.entity.OrderItem;
+import com.podmate.domain.orderForm.domain.repository.OrderFormRepository;
+import com.podmate.domain.orderForm.domain.repository.OrderItemRepository;
+import com.podmate.domain.platformInfo.exception.PlatformAccessDeniedException;
+import com.podmate.domain.pod.domain.entity.Pod;
+import com.podmate.domain.pod.domain.enums.Platform;
+import com.podmate.domain.pod.domain.repository.PodRepository;
+import com.podmate.domain.pod.exception.PodNotFoundException;
+import com.podmate.domain.podUserMapping.domain.entity.PodUserMapping;
+import com.podmate.domain.podUserMapping.domain.enums.IsApproved;
+import com.podmate.domain.podUserMapping.domain.enums.PodRole;
+import com.podmate.domain.podUserMapping.domain.repository.PodUserMappingRepository;
+import com.podmate.domain.user.domain.entity.User;
+import com.podmate.domain.user.domain.repository.UserRepository;
+import com.podmate.domain.user.exception.UserNotFoundException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class OrderFormServiceImpl implements OrderFormService{
+    private final UserRepository userRepository;
+    private final PodRepository podRepository;
+    private final CartItemRepository cartItemRepository;
+    private final OrderFormRepository orderFormRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final PodUserMappingRepository podUserMappingRepository;
+    @Override
+    public Long createOrderForm(Long userId, Long podId, List<Long> itemIds) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException());
+
+        Pod pod = podRepository.findById(podId)
+                .orElseThrow(() -> new PodNotFoundException());
+
+        // itemIds로 장바구니 아이템 조회
+        List<CartItem> cartItems = cartItemRepository.findAllById(itemIds);
+
+        validateCartItemOwnership(userId, cartItems);
+        int totalAmount = calculateTotalAmount(cartItems);
+        Platform platform = extractPlatformFromCartItems(cartItems);
+
+        // 1. OrderForm 생성 및 저장
+        OrderForm orderForm = saveOrderForm(user, totalAmount, platform);
+
+        // 2. 주문상품 (OrderItem) 생성 및 저장
+        saveOrderItems(orderForm, cartItems);
+
+        // 3. 팟-사용자 매핑 테이블 등록
+        savePodUserMapping(pod, user, orderForm);
+
+        return orderForm.getId(); // 생성한 주문서 Id 반환
+    }
+
+    // 유저 권한 체크 (내 장바구니 맞는지)
+    private void validateCartItemOwnership(Long userId, List<CartItem> cartItems) {
+        for (CartItem item : cartItems) {
+            if (!item.getPlatformInfo().getUser().getId().equals(userId)) {
+                throw new PlatformAccessDeniedException();
+            }
+        }
+    }
+
+    private int calculateTotalAmount(List<CartItem> cartItems) {
+        return cartItems.stream()
+                .mapToInt(item -> item.getPrice() * item.getQuantity())
+                .sum();
+    }
+
+    private Platform extractPlatformFromCartItems(List<CartItem> cartItems) {
+        String platformName = cartItems.get(0).getPlatformInfo().getPlatformName();
+        return Platform.validatePlatform(platformName);
+    }
+
+    private OrderForm saveOrderForm(User user, int totalAmount, Platform platform) {
+        OrderForm orderForm = OrderForm.builder()
+                .user(user)
+                .platform(platform)
+                .totalAmount(totalAmount)
+                .build();
+        return orderFormRepository.save(orderForm);
+    }
+
+    private void saveOrderItems(OrderForm orderForm, List<CartItem> cartItems) {
+        for (CartItem cartItem : cartItems) {
+            OrderItem orderItem = OrderItem.builder()
+                    .orderForm(orderForm)
+                    .itemName(cartItem.getItemName())
+                    .itemUrl(cartItem.getItemUrl())
+                    .quantity(cartItem.getQuantity())
+                    .optionText(cartItem.getOptionText())
+                    .price(cartItem.getPrice())
+                    .build();
+            orderItemRepository.save(orderItem);
+        }
+    }
+    private void savePodUserMapping(Pod pod, User user, OrderForm orderForm) {
+        PodUserMapping podUserMapping = PodUserMapping.updatePodUserMappingForOrderForm(
+                pod,
+                user,
+                orderForm,
+                IsApproved.PENDING, // 디폴트값 - 첫 주문서 신청 시, 팟장의 허락 전에는 PENDING
+                PodRole.POD_MEMBER // 디폴트값 - 신청서 넣는 사람은 팟장이 아닌 팟원
+        );
+        podUserMappingRepository.save(podUserMapping);
+    }
+
+}

--- a/be/src/main/java/com/podmate/domain/orderForm/domain/entity/OrderForm.java
+++ b/be/src/main/java/com/podmate/domain/orderForm/domain/entity/OrderForm.java
@@ -1,0 +1,50 @@
+package com.podmate.domain.orderForm.domain.entity;
+
+import com.podmate.domain.model.entity.BaseEntity;
+import com.podmate.domain.pod.domain.enums.Platform;
+import com.podmate.domain.user.domain.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "orderform")
+@Getter
+public class OrderForm extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_form_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "total_amount")
+    private int totalAmount; // 총금액
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Platform platform;
+
+    @Builder
+    public OrderForm(User user, int totalAmount, Platform platform){
+        this.user = user;
+        this.totalAmount = totalAmount;
+        this.platform = platform;
+    }
+
+}

--- a/be/src/main/java/com/podmate/domain/orderForm/domain/entity/OrderItem.java
+++ b/be/src/main/java/com/podmate/domain/orderForm/domain/entity/OrderItem.java
@@ -1,0 +1,55 @@
+package com.podmate.domain.orderForm.domain.entity;
+
+import com.podmate.domain.model.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "order_item")
+@Getter
+public class OrderItem extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_item_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_form_id")
+    private OrderForm orderForm;
+
+    @Column(name = "item_name")
+    private String itemName;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    @Column(name = "item_url", nullable = false)
+    private String itemUrl;
+
+    @Column(name = "option_text")
+    private String optionText;
+
+    private int price;
+
+    @Builder
+    public OrderItem(OrderForm orderForm, String itemName, int quantity, String itemUrl, String optionText, int price){
+        this.orderForm = orderForm;
+        this.itemName = itemName;
+        this.quantity = quantity;
+        this.itemUrl = itemUrl;
+        this.optionText = optionText;
+        this.price = price;
+    }
+}

--- a/be/src/main/java/com/podmate/domain/orderForm/domain/repository/OrderFormRepository.java
+++ b/be/src/main/java/com/podmate/domain/orderForm/domain/repository/OrderFormRepository.java
@@ -1,0 +1,8 @@
+package com.podmate.domain.orderForm.domain.repository;
+
+import com.podmate.domain.orderForm.domain.entity.OrderForm;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderFormRepository extends JpaRepository<OrderForm, Long> {
+
+}

--- a/be/src/main/java/com/podmate/domain/orderForm/domain/repository/OrderItemRepository.java
+++ b/be/src/main/java/com/podmate/domain/orderForm/domain/repository/OrderItemRepository.java
@@ -1,0 +1,8 @@
+package com.podmate.domain.orderForm.domain.repository;
+
+import com.podmate.domain.orderForm.domain.entity.OrderItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+
+}

--- a/be/src/main/java/com/podmate/domain/orderForm/dto/OrderFormRequestDto.java
+++ b/be/src/main/java/com/podmate/domain/orderForm/dto/OrderFormRequestDto.java
@@ -1,0 +1,14 @@
+package com.podmate.domain.orderForm.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+
+public class OrderFormRequestDto {
+    @Getter
+    public static class ItemIds {
+        private List<Long> items;
+    }
+
+
+}

--- a/be/src/main/java/com/podmate/domain/orderForm/dto/OrderFormResponseDto.java
+++ b/be/src/main/java/com/podmate/domain/orderForm/dto/OrderFormResponseDto.java
@@ -1,0 +1,9 @@
+package com.podmate.domain.orderForm.dto;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class OrderFormResponseDto {
+    private Long orderFormId;
+
+}

--- a/be/src/main/java/com/podmate/domain/podUserMapping/domain/entity/PodUserMapping.java
+++ b/be/src/main/java/com/podmate/domain/podUserMapping/domain/entity/PodUserMapping.java
@@ -2,6 +2,7 @@ package com.podmate.domain.podUserMapping.domain.entity;
 
 import com.podmate.domain.address.domain.entity.Address;
 import com.podmate.domain.model.entity.BaseEntity;
+import com.podmate.domain.orderForm.domain.entity.OrderForm;
 import com.podmate.domain.pod.domain.entity.Pod;
 import com.podmate.domain.pod.domain.enums.InprogressStatus;
 import com.podmate.domain.pod.domain.enums.Platform;
@@ -36,7 +37,9 @@ public class PodUserMapping extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    //private Order orderFormId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_form_id")
+    private OrderForm orderForm;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -52,6 +55,19 @@ public class PodUserMapping extends BaseEntity {
         this.user = user;
         this.isApproved = isApproved;
         this.podRole = podRole;
+    }
+
+
+    // 팩토리 메서드 패턴 추가
+    public static PodUserMapping updatePodUserMappingForOrderForm(Pod pod, User user, OrderForm orderForm, IsApproved isApproved, PodRole podRole) {
+        PodUserMapping mapping = new PodUserMapping();
+        mapping.pod = pod;
+        mapping.user = user;
+        mapping.orderForm = orderForm;
+        mapping.isApproved = isApproved;
+        mapping.podRole = podRole;
+
+        return mapping;
     }
 
 }


### PR DESCRIPTION
[feat/#60] 주문서 생성 api

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #

## 🌱 PR 요약
- 장바구니 목록에서 선택한 itemId 를 바탕으로, 주문하기 버튼을 누르면 주문서가 생성된다
- 이때 총 3개의 엔디티가 저장 / 업데이트된다 (OrderForm, OrderItem, PodUserMapping)


## 📸 스크린샷
![image](https://github.com/user-attachments/assets/2d2d57f8-9a2d-409a-b227-6976ff6aebee)
